### PR TITLE
Separated con2prim and compute_Tmunu for easier scheduling

### DIFF
--- a/implementations/GRHayLHD/interface.ccl
+++ b/implementations/GRHayLHD/interface.ccl
@@ -10,13 +10,17 @@ USES INCLUDE: GRHayLib.h
 #########################################################
 
 # Primitive variables
-# The HydroBase quantities rho and press are used as the primitives in this code. However,
+# The variables rho_b and pressure are identical to the HydroBase variables. However,
 # GRHayL uses the velocity v^i = u^i/u^0, while HydroBase uses the Valencia velocity, so
-# we declare our own velocities here.
+# these velocities differ from HydroBase.
 cctk_real grmhd_primitives type = GF TAGS='InterpNumTimelevels=1 prolongation="none"'
 {
   rho_b, pressure, vx, vy, vz
 } "Primitive variables density, pressure, and components of three velocity v^i. Note that v^i is defined in terms of 4-velocity as: v^i = u^i/u^0. Note that this definition differs from the Valencia formalism."
+
+# Separating the computation of Tmunu from the con2prim routine requires providing u0.
+# This is most easily done by adding another grid function.
+cctk_real u0 type = GF TAGS='InterpNumTimelevels=1 prolongation="none" checkpoint="no"' "4-velocity component u^0"
 
 #########################################################
 

--- a/implementations/GRHayLHD/schedule.ccl
+++ b/implementations/GRHayLHD/schedule.ccl
@@ -7,13 +7,8 @@ STORAGE: ADMBase::metric[metric_timelevels], ADMBase::curv[metric_timelevels], A
 # SC says: probably just need to properly set up hydrobase parameters
 STORAGE: HydroBase::rho[1],HydroBase::press[1],HydroBase::eps[1],HydroBase::vel[1]
 
-# Since the evolution code uses some HydroBase quantities, it is
-# important to set certain HydroBase parameters for intended behavior:
-# HydroBase::prolongation_type = 'none'
-# HydroBase::timelevels = 1
-
 STORAGE: grmhd_conservatives[3]
-STORAGE: grmhd_primitives, grmhd_conservatives_rhs
+STORAGE: grmhd_primitives, u0, grmhd_conservatives_rhs
 STORAGE: grmhd_flux_temps, diagnostic_gfs
 
 #########################################################
@@ -42,27 +37,21 @@ schedule group GRHayLHD_Prim2Con2Prim in HydroBase_Prim2ConInitial
 
 schedule GRHayLHD_enforce_detgtij_eq_1 in GRHayLHD_Prim2Con2Prim as first_initialdata
 {
-   LANG:       C
+   LANG: C
    READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
    WRITES: ADMBase::metric(everywhere)
-   #SC: loop is everywhere, so there should be no syncs; either the loop is wrong or there should be no syncs.
    SYNC: ADMBase::metric, ADMBase::lapse, ADMBase::shift, ADMBase::curv
 } "Enforce BSSN metric is conformally flat and recompute ADM metric"
 
 schedule convert_HydroBase_to_GRHayLHD in GRHayLHD_Prim2Con2Prim as second_initialdata after first_initialdata
 {
-   LANG:       C
+   LANG: C
    READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
    READS:  HydroBase::rho, HydroBase::press, HydroBase::eps,
            HydroBase::vel, HydroBase::Y_e, HydroBase::entropy,
            HydroBase::temperature
-   # Enforced limits on primitives can change the primitives
    WRITES: HydroBase::eps(everywhere)
    WRITES: grmhd_primitives(everywhere), grmhd_conservatives(everywhere)
-   WRITES: TmunuBase::stress_energy_scalar(everywhere),
-           TmunuBase::stress_energy_vector(everywhere),
-           TmunuBase::stress_energy_tensor(everywhere)
-   #SC: loop is everywhere, so there should be no syncs; either the loop is wrong or there should be no syncs.
    SYNC: grmhd_primitives, grmhd_conservatives
 } "Convert HydroBase initial data (ID) to GRHayLHD variables and enforce simulation limits on primitives"
 
@@ -71,11 +60,10 @@ schedule GRHayLHD_conserv_to_prims in GRHayLHD_Prim2Con2Prim as third_initialdat
   LANG: C
   READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
   READS:  grmhd_conservatives
-  WRITES: grmhd_primitives(everywhere), grmhd_conservatives(everywhere), failure_checker(everywhere)
+   # Con2Prim routine also recomputes conservatives after solving for primitives
+  WRITES: u0(everywhere), grmhd_primitives(everywhere),
+          grmhd_conservatives(everywhere), failure_checker(everywhere)
   WRITES: HydroBase::eps(everywhere)
-  WRITES: TmunuBase::stress_energy_scalar(everywhere),
-          TmunuBase::stress_energy_vector(everywhere),
-          TmunuBase::stress_energy_tensor(everywhere)
 } "Compute primitive variables from conservatives"
 
 schedule convert_GRHayLHD_to_HydroBase in GRHayLHD_Prim2Con2Prim as fourth_initialdata after third_initialdata
@@ -88,41 +76,66 @@ schedule convert_GRHayLHD_to_HydroBase in GRHayLHD_Prim2Con2Prim as fourth_initi
 } "Convert GRHayLHD-native variables to HydroBase"
 
 #########################################################
-# POSTPOSTINITIAL
+# Con2Prim
 #########################################################
-# SCupp: This would actually be unnecessary if IllinoisGRMHD had scheduled
-# Con2Prim in the actual HydroBase_Con2Prim bin, as every location con2prim
-# happens occurs right after this bin. However, since it also computes
-# Tmunu the function has to happen in AddtoTmunu...
 
-# HydroBase_Con2Prim in CCTK_POSTPOSTINITIAL sets conserv to prim then
-# outer boundaries (OBs, which are technically disabled). The post OB 
-# SYNCs actually reprolongate the conservative variables, making cons
-# and prims INCONSISTENT. So here we redo the con2prim, avoiding the 
-# SYNC afterward, then copy the result to other timelevels"
-schedule GROUP GRHayLHD_PostPostInitial at CCTK_POSTPOSTINITIAL
+schedule group GRHayLHD_Con2Prim in HydroBase_Con2Prim
 {
-} "HydroBase_Con2Prim in CCTK_POSTPOSTINITIAL sets conserv to prim then outer boundaries (OBs, which are technically disabled). The post OB SYNCs actually reprolongate the conservative variables, making cons and prims INCONSISTENT. So here we redo the con2prim, avoiding the SYNC afterward, then copy the result to other timelevels"
+} "Compute primitive variables from conservatives"
 
-# we should be able to get rid of this
-schedule GRHayLHD_InitSymBound in GRHayLHD_PostPostInitial as postid
+schedule GRHayLHD_empty_function in GRHayLHD_Con2Prim as GRHayLHD_sync_conservatives
 {
   LANG: C
   SYNC: grmhd_conservatives
-} "Schedule symmetries -- Actually just a placeholder function to ensure prolongations / processor syncs are done before outer boundaries are updated."
+} "Sync conservative variable ghost zones for c2p routine"
 
-# Nontrivial primitives solve, for P,rho_b,vx,vy,vz:
-schedule GRHayLHD_conserv_to_prims in GRHayLHD_PostPostInitial after postid
+schedule GRHayLHD_conserv_to_prims in GRHayLHD_Con2Prim after GRHayLHD_sync_conservatives
 {
   LANG: C
   READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
   READS:  grmhd_conservatives
+   # Con2Prim routine also recomputes conservatives after solving for primitives
+  WRITES: u0(everywhere), grmhd_primitives(everywhere),
+          grmhd_conservatives(everywhere), failure_checker(everywhere)
+  WRITES: HydroBase::eps(everywhere)
+} "Compute primitive variables from conservatives"
+
+schedule GRHayLHD_outer_boundaries_on_P_rho_b_vx_vy_vz in GRHayLHD_Con2Prim after GRHayLHD_conserv_to_prims
+{
+  LANG: C
+  READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
   WRITES: grmhd_primitives(everywhere), grmhd_conservatives(everywhere), failure_checker(everywhere)
   WRITES: HydroBase::eps(everywhere)
+  SYNC: grmhd_primitives
+} "Apply outflow-only, flat BCs on {P,rho_b,vx,vy,vz}. Outflow only == velocities pointed inward from outer boundary are set to zero."
+
+#########################################################
+# Stress-energy Tensor
+#########################################################
+schedule GRHayLHD_compute_Tmunu in AddToTmunu
+{
+  LANG: C
+  READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
+  READS:  HydroBase::eps
+  READS:  grmhd_primitives, u0
   WRITES: TmunuBase::stress_energy_scalar(everywhere),
           TmunuBase::stress_energy_vector(everywhere),
           TmunuBase::stress_energy_tensor(everywhere)
-} "Compute primitive variables from conservatives"
+} "Compute stress-energy tensor"
+
+# This preserves original IllinoisGRMHD behavior, but it's bad form.
+# This prevents usfrom making the Tmunu be "add" instead of "set".
+# The ET wants AddToTmunu, not SetTmunu.
+schedule GRHayLHD_compute_Tmunu at CCTK_POSTPOSTINITIAL after Con2Prim
+{
+  LANG: C
+  READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
+  READS:  HydroBase::eps
+  READS:  grmhd_primitives, u0
+  WRITES: TmunuBase::stress_energy_scalar(everywhere),
+          TmunuBase::stress_energy_vector(everywhere),
+          TmunuBase::stress_energy_tensor(everywhere)
+} "Compute stress-energy tensor"
 
 #########################################################
 # RHS EVALUATION
@@ -134,7 +147,7 @@ schedule group GRHayLHD_RHS in MoL_CalcRHS after (bssn_rhs shift_rhs)
 
 schedule GRHayLHD_enforce_detgtij_eq_1 in GRHayLHD_RHS
 {
-   LANG:       C
+   LANG: C
    READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
    WRITES: ADMBase::metric(everywhere)
 } "Convert ADM variables to GRHayLHD BSSN variables."
@@ -159,59 +172,7 @@ schedule GRHayLHD_evaluate_flux_source_rhs in GRHayLHD_RHS after GRHayLHD_evalua
 } "Evaluate RHSs of GRHD equations"
 
 #########################################################
-# COMPUTE B FROM A & RE-SOLVE FOR PRIMITIVES
-#########################################################
-# After a full timestep, there are two types of boundaries that need filling:
-# (A) Outer boundaries (on coarsest level)
-# (B) AMR grid refinement boundaries
-
-# (A) OUTER BOUNDARY STEPS:
-# ( 0) Synchronize (prolongate/restrict) all evolved variables
-# ( 1) Apply outer boundary conditions (BCs) on A_{\mu}
-# ( 2) Compute B^i from A_i everywhere, synchronize (processor sync) B^i
-# ( 3) Call con2prim to get consistent primitives {P,rho_b,vx,vy,vz} and conservatives at all points (if no restriction, really only need interior)
-# ( 4) Apply outer BCs on {P,rho_b,vx,vy,vz}, recompute conservatives.
-
-# (B) AMR GRID REFINEMENT BOUNDARY STEPS:
-# Same as steps 0,2,3 above. Just need if() statements in steps 1,4 to prevent "outer boundaries" being updated
-# Problem: all the sync's in outer boundary updates might just overwrite prolongated values.
-#########################################################
-
-# we should be able to get rid of this
-schedule GRHayLHD_InitSymBound in HydroBase_Boundaries as Boundary_SYNCs
-{
-  LANG: C
-  SYNC: grmhd_conservatives
-} "Schedule symmetries -- Actually just a placeholder function to ensure prolongations / processor syncs are done BEFORE outer boundaries are updated."
-
-# Nontrivial primitives solve, for P,rho_b,vx,vy,vz.
-schedule GRHayLHD_conserv_to_prims in AddToTmunu
-{
-  LANG: C
-  READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
-  READS:  grmhd_conservatives
-  WRITES: grmhd_primitives(everywhere), grmhd_conservatives(everywhere), failure_checker(everywhere)
-  WRITES: HydroBase::eps(everywhere)
-  WRITES: TmunuBase::stress_energy_scalar(everywhere),
-          TmunuBase::stress_energy_vector(everywhere),
-          TmunuBase::stress_energy_tensor(everywhere)
-} "Compute primitive variables from conservatives"
-
-schedule GRHayLHD_outer_boundaries_on_P_rho_b_vx_vy_vz in AddToTmunu after GRHayLHD_conserv_to_prims
-{
-  LANG: C
-  READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
-  WRITES: grmhd_primitives(everywhere), grmhd_conservatives(everywhere), failure_checker(everywhere)
-  WRITES: HydroBase::eps(everywhere)
-  WRITES: TmunuBase::stress_energy_scalar(everywhere),
-          TmunuBase::stress_energy_vector(everywhere),
-          TmunuBase::stress_energy_tensor(everywhere)
-# We must sync {P,rho_b,vx,vy,vz} here.
-  SYNC: grmhd_primitives
-} "Apply outflow-only, flat BCs on {P,rho_b,vx,vy,vz}. Outflow only == velocities pointed inward from outer boundary are set to zero."
-
-#########################################################
-# Conversion from GRHayLHD variables to Hydrobase
+# Set HydroBase variables for analysis
 #########################################################
 
 SCHEDULE convert_GRHayLHD_to_HydroBase at CCTK_ANALYSIS before (particle_tracerET VolumeIntegralGroup convert_to_MHD_3velocity) after ML_BSSN_evolCalcGroup
@@ -223,5 +184,3 @@ SCHEDULE convert_GRHayLHD_to_HydroBase at CCTK_ANALYSIS before (particle_tracerE
   WRITES: HydroBase::rho(everywhere), HydroBase::press(everywhere),
           HydroBase::vel(everywhere), HydroBase::w_lorentz(everywhere), HydroBase::Bvec(everywhere)
 } "Convert GRHayLHD-native variables to HydroBase"
-
-#########################################################

--- a/implementations/GRHayLHD/src/InitSymBound.c
+++ b/implementations/GRHayLHD/src/InitSymBound.c
@@ -41,3 +41,7 @@ void GRHayLHD_InitSymBound(CCTK_ARGUMENTS)
     }
   }
 }
+
+void GRHayLHD_empty_function(CCTK_ARGUMENTS)
+{
+}

--- a/implementations/GRHayLHD/src/compute_Tmunu.c
+++ b/implementations/GRHayLHD/src/compute_Tmunu.c
@@ -1,0 +1,49 @@
+#include "GRHayLHD.h"
+
+void GRHayLHD_compute_Tmunu(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTS_GRHayLHD_compute_Tmunu;
+  DECLARE_CCTK_PARAMETERS;
+
+  const double poison = 0.0/0.0;
+
+#pragma omp parallel for
+  for(int k=0; k<cctk_lsh[2]; k++) {
+    for(int j=0; j<cctk_lsh[1]; j++) {
+      for(int i=0; i<cctk_lsh[0]; i++) {
+        const int index = CCTK_GFINDEX3D(cctkGH,i,j,k);
+
+        // Read in ADM metric quantities from gridfunctions and
+        // set auxiliary and ADM metric quantities
+        metric_quantities ADM_metric;
+        ghl_enforce_detgtij_and_initialize_ADM_metric(
+              alp[index],
+              betax[index], betay[index], betaz[index],
+              gxx[index], gxy[index], gxz[index],
+              gyy[index], gyz[index], gzz[index],
+              &ADM_metric);
+
+        ADM_aux_quantities metric_aux;
+        ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+
+        // Read in primitive variables from gridfunctions
+        primitive_quantities prims;
+        ghl_initialize_primitives(
+              rho_b[index], pressure[index], eps[index],
+              vx[index], vy[index], vz[index],
+              0.0, 0.0, 0.0,
+              poison, poison, poison, &prims);
+
+        prims.u0 = u0[index];
+
+        stress_energy Tmunu;
+        ghl_compute_TDNmunu(&ADM_metric, &metric_aux, &prims, &Tmunu);
+
+        ghl_return_stress_energy(
+              &Tmunu, &eTtt[index], &eTtx[index],
+              &eTty[index], &eTtz[index], &eTxx[index],
+              &eTxy[index], &eTxz[index], &eTyy[index],
+              &eTyz[index], &eTzz[index]);
+      }
+    }
+  }
+}

--- a/implementations/GRHayLHD/src/convert_HydroBase_to_GRHayLHD.c
+++ b/implementations/GRHayLHD/src/convert_HydroBase_to_GRHayLHD.c
@@ -113,15 +113,14 @@ void convert_HydroBase_to_GRHayLHD(CCTK_ARGUMENTS) {
               &prims);
 
         conservative_quantities cons;
-        stress_energy Tmunu;
         int speed_limited = 0;
         //This applies inequality fixes on the conservatives
         ghl_enforce_primitive_limits_and_compute_u0(
               grhayl_params, grhayl_eos, &ADM_metric,
               &metric_aux, &prims, &speed_limited);
-        //This computes the conservatives and stress-energy tensor from the new primitives
-        ghl_compute_conservs_and_Tmunu(
-              &ADM_metric, &metric_aux, &prims, &cons, &Tmunu);
+        //This computes the conservatives from the new primitives
+        ghl_compute_conservs(
+              &ADM_metric, &metric_aux, &prims, &cons);
 
         ghl_return_primitives(
               &prims,
@@ -135,14 +134,6 @@ void convert_HydroBase_to_GRHayLHD(CCTK_ARGUMENTS) {
               &rho_star[index], &tau[index],
               &Stildex[index], &Stildey[index], &Stildez[index],
               &dummy1, &dummy2);
-
-        if(update_Tmunu) {
-          ghl_return_stress_energy(
-                &Tmunu, &eTtt[index], &eTtx[index],
-                &eTty[index], &eTtz[index], &eTxx[index],
-                &eTxy[index], &eTxz[index], &eTyy[index],
-                &eTyz[index], &eTzz[index]);
-        }
       }
     }
   }

--- a/implementations/GRHayLHD/src/make.code.defn
+++ b/implementations/GRHayLHD/src/make.code.defn
@@ -3,6 +3,7 @@
 # Source files in this directory
 SRCS = conservs_to_prims.c                         \
        enforce_detgtij_eq_1.c                      \
+       compute_Tmunu.c                             \
        convert_HydroBase_to_GRHayLHD.c             \
        convert_GRHayLHD_to_HydroBase.c             \
        evaluate_flux_source_rhs.c                  \

--- a/implementations/GRHayLHD/src/outer_boundaries.c
+++ b/implementations/GRHayLHD/src/outer_boundaries.c
@@ -11,7 +11,7 @@
 
 #include "GRHayLHD.h"
 
-#define IDX(i,j,k) CCTK_GFINDEX3D(cctkGH,(i),(j),(k))
+void GRHayLHD_enforce_primitive_limits_and_compute_conservs(const cGH* cctkGH, const int index);
 
 /*******************************************************
  * Apply outer boundary conditions on {P,rho_b,vx,vy,vz}
@@ -44,12 +44,15 @@ void GRHayLHD_outer_boundaries_on_P_rho_b_vx_vy_vz(CCTK_ARGUMENTS) {
 #pragma omp parallel for
       for(int k=0; k<cctk_lsh[2]; k++) {
         for(int j=0; j<cctk_lsh[1]; j++) {
-          pressure[IDX(imax,j,k)] = pressure[IDX(imax-1,j,k)];
-          rho_b[IDX(imax,j,k)]   = rho_b[IDX(imax-1,j,k)];
-          vx[IDX(imax,j,k)]    = vx[IDX(imax-1,j,k)];
-          vy[IDX(imax,j,k)]    = vy[IDX(imax-1,j,k)];
-          vz[IDX(imax,j,k)]    = vz[IDX(imax-1,j,k)]; 
-          if(vx[IDX(imax,j,k)]<0.) vx[IDX(imax,j,k)] = 0.0;
+          const int indm1 = CCTK_GFINDEX3D(cctkGH,imax-1, j, k);
+          const int index = CCTK_GFINDEX3D(cctkGH,imax, j, k);
+          pressure[index] = pressure[indm1];
+          rho_b[index]    = rho_b[indm1];
+          vx[index]       = vx[indm1];
+          vy[index]       = vy[indm1];
+          vz[index]       = vz[indm1]; 
+          if(vx[index]<0.) vx[index] = 0.0;
+          GRHayLHD_enforce_primitive_limits_and_compute_conservs(cctkGH, index);
         }
       }
     }
@@ -59,12 +62,15 @@ void GRHayLHD_outer_boundaries_on_P_rho_b_vx_vy_vz(CCTK_ARGUMENTS) {
 #pragma omp parallel for
       for(int k=0; k<cctk_lsh[2]; k++) {
         for(int j=0; j<cctk_lsh[1]; j++) {
-          pressure[IDX(imin,j,k)] = pressure[IDX(imin+1,j,k)];
-          rho_b[IDX(imin,j,k)]   = rho_b[IDX(imin+1,j,k)];
-          vx[IDX(imin,j,k)]    = vx[IDX(imin+1,j,k)];
-          vy[IDX(imin,j,k)]    = vy[IDX(imin+1,j,k)];
-          vz[IDX(imin,j,k)]    = vz[IDX(imin+1,j,k)]; 
-          if(vx[IDX(imin,j,k)]>0.) vx[IDX(imin,j,k)] = 0.0;
+          const int index = CCTK_GFINDEX3D(cctkGH, imin, j, k);
+          const int indp1 = CCTK_GFINDEX3D(cctkGH, imin+1, j, k);
+          pressure[index] = pressure[indp1];
+          rho_b[index]    = rho_b[indp1];
+          vx[index]       = vx[indp1];
+          vy[index]       = vy[indp1];
+          vz[index]       = vz[indp1]; 
+          if(vx[index]>0.) vx[index] = 0.0;
+          GRHayLHD_enforce_primitive_limits_and_compute_conservs(cctkGH, index);
         }
       }
     }
@@ -76,12 +82,15 @@ void GRHayLHD_outer_boundaries_on_P_rho_b_vx_vy_vz(CCTK_ARGUMENTS) {
 #pragma omp parallel for
       for(int k=0; k<cctk_lsh[2]; k++) {
         for(int i=0; i<cctk_lsh[0]; i++) {
-          pressure[IDX(i,jmax,k)] = pressure[IDX(i,jmax-1,k)];
-          rho_b[IDX(i,jmax,k)]   = rho_b[IDX(i,jmax-1,k)];
-          vx[IDX(i,jmax,k)]    = vx[IDX(i,jmax-1,k)];
-          vy[IDX(i,jmax,k)]    = vy[IDX(i,jmax-1,k)];
-          vz[IDX(i,jmax,k)]    = vz[IDX(i,jmax-1,k)]; 
-          if(vx[IDX(i,jmax,k)]<0.) vx[IDX(i,jmax,k)] = 0.0;
+          const int indm1 = CCTK_GFINDEX3D(cctkGH, i, jmax-1, k);
+          const int index = CCTK_GFINDEX3D(cctkGH, i, jmax, k);
+          pressure[index] = pressure[indm1];
+          rho_b[index]    = rho_b[indm1];
+          vx[index]       = vx[indm1];
+          vy[index]       = vy[indm1];
+          vz[index]       = vz[indm1]; 
+          if(vx[index]<0.) vx[index] = 0.0;
+          GRHayLHD_enforce_primitive_limits_and_compute_conservs(cctkGH, index);
         }
       }
     }
@@ -91,12 +100,15 @@ void GRHayLHD_outer_boundaries_on_P_rho_b_vx_vy_vz(CCTK_ARGUMENTS) {
 #pragma omp parallel for
       for(int k=0; k<cctk_lsh[2]; k++) {
         for(int i=0; i<cctk_lsh[0]; i++) {
-          pressure[IDX(i,jmin,k)] = pressure[IDX(i,jmin+1,k)];
-          rho_b[IDX(i,jmin,k)]   = rho_b[IDX(i,jmin+1,k)];
-          vx[IDX(i,jmin,k)]    = vx[IDX(i,jmin+1,k)];
-          vy[IDX(i,jmin,k)]    = vy[IDX(i,jmin+1,k)];
-          vz[IDX(i,jmin,k)]    = vz[IDX(i,jmin+1,k)]; 
-          if(vx[IDX(i,jmin,k)]>0.) vx[IDX(i,jmin,k)] = 0.0;
+          const int index = CCTK_GFINDEX3D(cctkGH, i, jmin, k);
+          const int indp1 = CCTK_GFINDEX3D(cctkGH, i, jmin+1, k);
+          pressure[index] = pressure[indp1];
+          rho_b[index]    = rho_b[indp1];
+          vx[index]       = vx[indp1];
+          vy[index]       = vy[indp1];
+          vz[index]       = vz[indp1]; 
+          if(vx[index]>0.) vx[index] = 0.0;
+          GRHayLHD_enforce_primitive_limits_and_compute_conservs(cctkGH, index);
         }
       }
     }
@@ -108,12 +120,15 @@ void GRHayLHD_outer_boundaries_on_P_rho_b_vx_vy_vz(CCTK_ARGUMENTS) {
 #pragma omp parallel for
       for(int j=0; j<cctk_lsh[1]; j++) {
         for(int i=0; i<cctk_lsh[0]; i++) {
-          pressure[IDX(i,j,kmax)] = pressure[IDX(i,j,kmax-1)];
-          rho_b[IDX(i,j,kmax)]   = rho_b[IDX(i,j,kmax-1)];
-          vx[IDX(i,j,kmax)]    = vx[IDX(i,j,kmax-1)];
-          vy[IDX(i,j,kmax)]    = vy[IDX(i,j,kmax-1)];
-          vz[IDX(i,j,kmax)]    = vz[IDX(i,j,kmax-1)]; 
-          if(vx[IDX(i,j,kmax)]<0.) vx[IDX(i,j,kmax)] = 0.0;
+          const int indm1 = CCTK_GFINDEX3D(cctkGH, i, j, kmax-1);
+          const int index = CCTK_GFINDEX3D(cctkGH, i, j, kmax);
+          pressure[index] = pressure[indm1];
+          rho_b[index]    = rho_b[indm1];
+          vx[index]       = vx[indm1];
+          vy[index]       = vy[indm1];
+          vz[index]       = vz[indm1]; 
+          if(vx[index]<0.) vx[index] = 0.0;
+          GRHayLHD_enforce_primitive_limits_and_compute_conservs(cctkGH, index);
         }
       }
     }
@@ -123,85 +138,67 @@ void GRHayLHD_outer_boundaries_on_P_rho_b_vx_vy_vz(CCTK_ARGUMENTS) {
 #pragma omp parallel for
       for(int j=0; j<cctk_lsh[1]; j++) {
         for(int i=0; i<cctk_lsh[0]; i++) {
-          pressure[IDX(i,j,kmin)] = pressure[IDX(i,j,kmin+1)];
-          rho_b[IDX(i,j,kmin)]   = rho_b[IDX(i,j,kmin+1)];
-          vx[IDX(i,j,kmin)]    = vx[IDX(i,j,kmin+1)];
-          vy[IDX(i,j,kmin)]    = vy[IDX(i,j,kmin+1)];
-          vz[IDX(i,j,kmin)]    = vz[IDX(i,j,kmin+1)]; 
-          if(vx[IDX(i,j,kmin)]>0.) vx[IDX(i,j,kmin)] = 0.0;
+          const int index = CCTK_GFINDEX3D(cctkGH, i, j, kmin);
+          const int indp1 = CCTK_GFINDEX3D(cctkGH, i, j, kmin+1);
+          pressure[index] = pressure[indp1];
+          rho_b[index]    = rho_b[indp1];
+          vx[index]       = vx[indp1];
+          vy[index]       = vy[indp1];
+          vz[index]       = vz[indp1]; 
+          if(vx[index]>0.) vx[index] = 0.0;
+          GRHayLHD_enforce_primitive_limits_and_compute_conservs(cctkGH, index);
         }
       }
     }
   }
+}
+
+void GRHayLHD_enforce_primitive_limits_and_compute_conservs(const cGH* cctkGH, const int index) {
+  // We cheat here by using the argument list of the scheduled function
+  // instead of explicitly passing all these variables.
+  DECLARE_CCTK_ARGUMENTS_GRHayLHD_outer_boundaries_on_P_rho_b_vx_vy_vz;
 
   const double poison = 0.0/0.0;
   double dummy1, dummy2, dummy3;
   double dummy4, dummy5, dummy6;
+  int speed_limited = 0;
 
-#pragma omp parallel for
-  for(int k=0; k<cctk_lsh[2]; k++) {
-    for(int j=0; j<cctk_lsh[1]; j++) {
-      for(int i=0; i<cctk_lsh[0]; i++) {
-        if(((cctk_bbox[0]) && i<cctk_nghostzones[0]) ||
-           ((cctk_bbox[1]) && i>=cctk_lsh[0]-cctk_nghostzones[0]) ||
-           ((cctk_bbox[2]) && j<cctk_nghostzones[1]) ||
-           ((cctk_bbox[3]) && j>=cctk_lsh[1]-cctk_nghostzones[1]) ||
-           ((cctk_bbox[4]) && k<cctk_nghostzones[2] && CCTK_EQUALS(Symmetry,"none")) ||
-           ((cctk_bbox[5]) && k>=cctk_lsh[2]-cctk_nghostzones[2])) {
-          const int index = CCTK_GFINDEX3D(cctkGH,i,j,k);
+  metric_quantities ADM_metric;
+  ghl_enforce_detgtij_and_initialize_ADM_metric(
+        alp[index],
+        betax[index], betay[index], betaz[index],
+        gxx[index], gxy[index], gxz[index],
+        gyy[index], gyz[index], gzz[index],
+        &ADM_metric);
 
-          metric_quantities ADM_metric;
-          ghl_enforce_detgtij_and_initialize_ADM_metric(
-                alp[index],
-                betax[index], betay[index], betaz[index],
-                gxx[index], gxy[index], gxz[index],
-                gyy[index], gyz[index], gzz[index],
-                &ADM_metric);
-      
-        ADM_aux_quantities metric_aux;
-        ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+  ADM_aux_quantities metric_aux;
+  ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-          primitive_quantities prims;
-          ghl_initialize_primitives(
-                rho_b[index], pressure[index], eps[index],
-                vx[index], vy[index], vz[index],
-                0.0, 0.0, 0.0,
-                poison, poison, poison, &prims);
-                //wont have storage for these vars for hybrid
-                //entropy[index], Y_e[index], temperature[index], &prims);
+  primitive_quantities prims;
+  ghl_initialize_primitives(
+        rho_b[index], pressure[index], eps[index],
+        vx[index], vy[index], vz[index],
+        0.0, 0.0, 0.0,
+        poison, poison, poison, &prims);
 
-          conservative_quantities cons;
-          stress_energy Tmunu;
-          int speed_limited = 0;
-          ghl_enforce_primitive_limits_and_compute_u0(
-                grhayl_params, grhayl_eos, &ADM_metric,
-                &metric_aux, &prims, &speed_limited);
-          ghl_compute_conservs_and_Tmunu(
-                &ADM_metric, &metric_aux, &prims, &cons, &Tmunu);
+  conservative_quantities cons;
+  ghl_enforce_primitive_limits_and_compute_u0(
+        grhayl_params, grhayl_eos, &ADM_metric,
+        &metric_aux, &prims, &speed_limited);
 
-          ghl_return_primitives(
-                &prims,
-                &rho_b[index], &pressure[index], &eps[index],
-                &vx[index], &vy[index], &vz[index],
-                &dummy1, &dummy2, &dummy3,
-                &dummy4, &dummy5, &dummy6);
+  ghl_compute_conservs(
+        &ADM_metric, &metric_aux, &prims, &cons);
 
-          ghl_return_conservatives(
-                &cons,
-                &rho_star[index], &tau[index],
-                &Stildex[index], &Stildey[index], &Stildez[index],
-                &dummy1, &dummy2);
-                //&Y_e[index], &entropy[index]);
+  ghl_return_primitives(
+        &prims,
+        &rho_b[index], &pressure[index], &eps[index],
+        &vx[index], &vy[index], &vz[index],
+        &dummy1, &dummy2, &dummy3,
+        &dummy4, &dummy5, &dummy6);
 
-          if(update_Tmunu) {
-            ghl_return_stress_energy(
-                  &Tmunu, &eTtt[index], &eTtx[index],
-                  &eTty[index], &eTtz[index], &eTxx[index],
-                  &eTxy[index], &eTxz[index], &eTyy[index],
-                  &eTyz[index], &eTzz[index]);
-          }
-        }
-      }
-    }
-  }
+  ghl_return_conservatives(
+        &cons,
+        &rho_star[index], &tau[index],
+        &Stildex[index], &Stildey[index], &Stildez[index],
+        &dummy1, &dummy2);
 }

--- a/implementations/GRHayLMHD/interface.ccl
+++ b/implementations/GRHayLMHD/interface.ccl
@@ -20,13 +20,17 @@ CCTK_REAL BSSN_quantities type = GF TAGS='prolongation="none" Checkpoint="no"'
 #########################################################
 
 # Primitive variables
-# The HydroBase quantities rho and press are used as the primitives in this code. However,
+# The variables rho_b and pressure are identical to the HydroBase variables. However,
 # GRHayL uses the velocity v^i = u^i/u^0, while HydroBase uses the Valencia velocity, so
-# we declare our own velocities here.
+# these velocities differ from HydroBase.
 cctk_real grmhd_primitives_allbutBi type = GF TAGS='InterpNumTimelevels=1 prolongation="none"'
 {
   rho_b, pressure, vx, vy, vz
 } "Primitive variables density, pressure, and components of three velocity v^i. Note that v^i is defined in terms of 4-velocity as: v^i = u^i/u^0. Note that this definition differs from the Valencia formalism."
+
+# Separating the computation of Tmunu from the con2prim routine requires providing u0.
+# This is most easily done by adding another grid function.
+cctk_real u0 type = GF TAGS='InterpNumTimelevels=1 prolongation="none" checkpoint="no"' "4-velocity component u^0"
 
 #########################################################
 

--- a/implementations/GRHayLMHD/schedule.ccl
+++ b/implementations/GRHayLMHD/schedule.ccl
@@ -7,17 +7,13 @@ STORAGE: ADMBase::metric[metric_timelevels], ADMBase::curv[metric_timelevels], A
 # SC says: probably just need to properly set up hydrobase parameters
 STORAGE: HydroBase::rho[1],HydroBase::press[1],HydroBase::eps[1],HydroBase::vel[1],HydroBase::Bvec[1],HydroBase::Avec[1],HydroBase::Aphi[1]
 
-# Since the evolution code uses some HydroBase quantities, it is
-# important to set certain HydroBase parameters for intended behavior:
-# HydroBase::prolongation_type = 'none'
-# HydroBase::timelevels = 1
 #TODO: is this needed?
 # This will only allocate a single timelevel of storage if it's not already been allocated.
 STORAGE: HydroBase::Avec[1], HydroBase::Aphi[1]
 
 STORAGE: BSSN_quantities
 STORAGE: grmhd_conservatives[3], em_Ax[3], em_Ay[3], em_Az[3], em_psi6phi[3] 
-STORAGE: grmhd_primitives_allbutBi, grmhd_B_center, grmhd_B_stagger
+STORAGE: grmhd_primitives_allbutBi, u0, grmhd_B_center, grmhd_B_stagger
 STORAGE: grmhd_conservatives_rhs, EM_rhs
 STORAGE: grmhd_primitives_reconstructed_temps, grmhd_cmin_cmax_temps, grmhd_flux_temps, diagnostic_gfs
 
@@ -45,17 +41,16 @@ schedule group GRHayLMHD_Prim2Con2Prim in HydroBase_Prim2ConInitial
 {
 } "Translate ET-generated, HydroBase-compatible initial data and convert into variables used by GRHayLMHD"
 
-schedule GRHayLMHD_convert_ADM_to_BSSN in GRHayLMHD_Prim2Con2Prim as first_initialdata
+schedule GRHayLMHD_convert_ADM_to_BSSN in GRHayLMHD_Prim2Con2Prim
 {
    LANG: C
    READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
    WRITES: ADMBase::metric(everywhere)
    WRITES: BSSN_quantities(everywhere)
-   #SC: loop is everywhere, so there should be no syncs; either the loop is wrong or there should be no syncs.
    SYNC: BSSN_quantities, ADMBase::metric, ADMBase::lapse, ADMBase::shift, ADMBase::curv
 } "Enforce BSSN metric is conformally flat and recompute ADM metric."
 
-schedule convert_HydroBase_to_GRHayLMHD in GRHayLMHD_Prim2Con2Prim as second_initialdata after first_initialdata
+schedule convert_HydroBase_to_GRHayLMHD in GRHayLMHD_Prim2Con2Prim after GRHayLMHD_convert_ADM_to_BSSN
 {
    LANG: C
    READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
@@ -63,38 +58,15 @@ schedule convert_HydroBase_to_GRHayLMHD in GRHayLMHD_Prim2Con2Prim as second_ini
            HydroBase::vel, HydroBase::Y_e, HydroBase::entropy,
            HydroBase::temperature, HydroBase::Avec, HydroBase::Aphi
    READS:  psi_bssn
-   # Enforced limits on primitives can change the primitives
-   WRITES: HydroBase::eps(everywhere)
+   WRITES: HydroBase::eps
    WRITES: grmhd_primitives_allbutBi(everywhere), grmhd_conservatives(everywhere),
            grmhd_B_center(everywhere), grmhd_B_stagger(everywhere),
            Ax(everywhere), Ay(everywhere), Az(everywhere),
            phitilde(everywhere)
-   WRITES: TmunuBase::stress_energy_scalar(everywhere),
-           TmunuBase::stress_energy_vector(everywhere),
-           TmunuBase::stress_energy_tensor(everywhere)
-   #SC: loop is everywhere, so there should be no syncs; either the loop is wrong or there should be no syncs.
    SYNC: grmhd_B_center, grmhd_B_stagger, grmhd_primitives_allbutBi, em_Ax, em_Ay, em_Az, em_psi6phi, grmhd_conservatives
 } "Convert HydroBase initial data (ID) to GRHayLMHD variables and enforce simulation limits on primitives."
 
-## these syncs happened in the previous function, so why do them again? A lot of extra computation going on in here
-#schedule GRHayLMHD_InitSymBound in GRHayLMHD_Prim2Con2Prim as third_initialdata after second_initialdata
-#{
-#  LANG: C
-#  SYNC: grmhd_conservatives, em_Ax, em_Ay, em_Az, em_psi6phi
-#} "Schedule symmetries -- Actually just a placeholder function to ensure prolongation / processor syncs are done BEFORE the primitives solver."
-#
-## this is clearly unnecessary; however, this was original behavior
-#schedule GRHayLMHD_convert_ADM_to_BSSN in GRHayLMHD_Prim2Con2Prim as fourth_initialdata after third_initialdata
-#{
-#   LANG: C
-#   READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
-#   WRITES: ADMBase::metric(everywhere)
-#   WRITES: BSSN_quantities(everywhere)
-#   #SC: loop is everywhere, so there should be no syncs; either the loop is wrong or there should be no syncs.
-#} "Enforce BSSN metric is conformally flat and recompute ADM metric."
-
-#TODO: Again, syncs are being done despite the fact that the function loops over all points; either sync or loop everywhere, not both
-schedule GRHayLMHD_compute_B_and_Bstagger_from_A in GRHayLMHD_Prim2Con2Prim as third_initialdata after second_initialdata
+schedule GRHayLMHD_compute_B_and_Bstagger_from_A in GRHayLMHD_Prim2Con2Prim after convert_HydroBase_to_GRHayLMHD
 {
   LANG: C
   READS:  GRID::coordinates
@@ -106,22 +78,17 @@ schedule GRHayLMHD_compute_B_and_Bstagger_from_A in GRHayLMHD_Prim2Con2Prim as t
   SYNC: grmhd_B_center, grmhd_B_stagger
 } "Compute B and B_stagger from A"
 
-schedule GRHayLMHD_conserv_to_prims in GRHayLMHD_Prim2Con2Prim as fourth_initialdata after third_initialdata
+schedule GRHayLMHD_conserv_to_prims in GRHayLMHD_Prim2Con2Prim after GRHayLMHD_compute_B_and_Bstagger_from_A
 {
   LANG: C
   READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
   READS:  grmhd_conservatives, grmhd_B_center
-  # C2P Shouldn't actually change B^i, but we return the values via the return_primitives() anyways
-  # in the event a new C2P for some reason touches B^i
   WRITES: grmhd_primitives_allbutBi(everywhere), grmhd_B_center(everywhere),
-          grmhd_conservatives(everywhere), failure_checker(everywhere)
+          u0(everywhere), grmhd_conservatives(everywhere), failure_checker(everywhere)
   WRITES: HydroBase::eps(everywhere)
-  WRITES: TmunuBase::stress_energy_scalar(everywhere),
-          TmunuBase::stress_energy_vector(everywhere),
-          TmunuBase::stress_energy_tensor(everywhere)
-} "Compute primitive variables from conservatives. This is non-trivial, requiring a Newton-Raphson root-finder."
+} "Compute primitive variables from conservatives"
 
-SCHEDULE convert_GRHayLMHD_to_HydroBase in GRHayLMHD_Prim2Con2Prim as fifth_initialdata after fourth_initialdata
+SCHEDULE convert_GRHayLMHD_to_HydroBase in GRHayLMHD_Prim2Con2Prim after GRHayLMHD_conserv_to_prims
 {
   LANG: C
   READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
@@ -131,29 +98,47 @@ SCHEDULE convert_GRHayLMHD_to_HydroBase in GRHayLMHD_Prim2Con2Prim as fifth_init
 } "Convert GRHayLMHD-native variables to HydroBase"
 
 #########################################################
-# POSTPOSTINITIAL
+# Symmetry setup (inherited from IllinoisGRMHD, where
+# it is still incomplete)
 #########################################################
-# HydroBase_Con2Prim in CCTK_POSTPOSTINITIAL sets conserv to prim then
-# outer boundaries (OBs, which are technically disabled). The post OB 
-# SYNCs actually reprolongate the conservative variables, making cons
-# and prims INCONSISTENT. So here we redo the con2prim, avoiding the 
-# SYNC afterward, then copy the result to other timelevels"
-schedule GROUP GRHayLMHD_PostPostInitial at CCTK_POSTPOSTINITIAL before MoL_PostStep after HydroBase_Con2Prim # get rid of these before after
-{
-} "HydroBase_Con2Prim in CCTK_POSTPOSTINITIAL sets conserv to prim then outer boundaries (OBs, which are technically disabled). The post OB SYNCs actually reprolongate the conservative variables, making cons and prims INCONSISTENT. So here we redo the con2prim, avoiding the SYNC afterward, then copy the result to other timelevels"
 
-schedule GRHayLMHD_convert_ADM_to_BSSN in GRHayLMHD_PostPostInitial
+schedule GRHayLMHD_set_gz_symmetries in CCTK_POSTPOSTINITIAL after Con2Prim
 {
-   LANG: C
-   READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
-   WRITES: ADMBase::metric(everywhere)
-   WRITES: BSSN_quantities(everywhere)
+  LANG: C
+  READS:  GRID::coordinates
+  READS:  grmhd_conservatives,
+          grmhd_B_center, grmhd_B_stagger,
+          phitilde, Ax, Ay, Az
+  #Technically only writes B^i, A_i, and phitilde in symmetry gz's
+  WRITES: grmhd_B_center(everywhere), grmhd_B_stagger(everywhere),
+          phitilde(everywhere), Ax(everywhere), Ay(everywhere), Az(everywhere)
+} "Compute post-initialdata quantities"
+
+#########################################################
+# Con2Prim
+#########################################################
+
+schedule group GRHayLMHD_Con2Prim in HydroBase_Con2Prim
+{
+} "Compute primitive variables from conservatives"
+
+schedule GRHayLMHD_convert_ADM_to_BSSN in GRHayLMHD_Con2Prim
+{
+  LANG: C
+  READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
+  WRITES: ADMBase::metric(everywhere)
+  WRITES: BSSN_quantities(everywhere)
   SYNC: grmhd_conservatives, em_Ax, em_Ay, em_Az, em_psi6phi
 } "Enforce BSSN metric is conformally flat and recompute ADM metric."
 
-# Again, loop over everywhere + sync
-# Easiest primitives to solve for: B^i
-schedule GRHayLMHD_compute_B_and_Bstagger_from_A in GRHayLMHD_PostPostInitial as compute_b after GRHayLMHD_convert_ADM_to_BSSN
+schedule GRHayLMHD_outer_boundaries_on_A_mu in GRHayLMHD_Con2Prim after GRHayLMHD_convert_ADM_to_BSSN
+{
+  LANG: C
+  READS:  phitilde, Ax, Ay, Az
+  WRITES: phitilde(boundary), Ax(boundary), Ay(boundary), Az(boundary)
+} "Apply linear extrapolation BCs on A_{mu}, so that BCs are flat on B^i"
+ 
+schedule GRHayLMHD_compute_B_and_Bstagger_from_A in GRHayLMHD_Con2Prim after GRHayLMHD_outer_boundaries_on_A_mu
 {
   LANG: C
   READS:  GRID::coordinates
@@ -166,38 +151,58 @@ schedule GRHayLMHD_compute_B_and_Bstagger_from_A in GRHayLMHD_PostPostInitial as
   SYNC: grmhd_B_center, grmhd_B_stagger # FIXME: Are both SYNC's necessary?
 } "Compute B and B_stagger from A SYNC: grmhd_primitives_Bi,grmhd_primitives_Bi_stagger"
 
-# Nontrivial primitives solve, for P,rho_b,vx,vy,vz:
-schedule GRHayLMHD_conserv_to_prims in GRHayLMHD_PostPostInitial after compute_b
+schedule GRHayLMHD_conserv_to_prims in GRHayLMHD_Con2Prim after GRHayLMHD_compute_B_and_Bstagger_from_A
 {
   LANG: C
   READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
   READS:  grmhd_conservatives, grmhd_B_center
-  # C2P Shouldn't actually change B^i, but we return the values via the return_primitives() anyways
-  # in the event a new C2P for some reason touches B^i
+  WRITES: grmhd_primitives_allbutBi(everywhere), grmhd_B_center(everywhere),
+          u0(everywhere), grmhd_conservatives(everywhere), failure_checker(everywhere)
+  WRITES: HydroBase::eps(everywhere)
+} "Compute primitive variables from conservatives"
+
+schedule GRHayLMHD_outer_boundaries_on_P_rho_b_vx_vy_vz in GRHayLMHD_Con2Prim after GRHayLMHD_conserv_to_prims
+{
+  LANG: C
+  READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
+  READS:  grmhd_B_center
   WRITES: grmhd_primitives_allbutBi(everywhere), grmhd_B_center(everywhere),
           grmhd_conservatives(everywhere), failure_checker(everywhere)
   WRITES: HydroBase::eps(everywhere)
   WRITES: TmunuBase::stress_energy_scalar(everywhere),
           TmunuBase::stress_energy_vector(everywhere),
           TmunuBase::stress_energy_tensor(everywhere)
-} "Compute primitive variables from conservatives. This is non-trivial, requiring a Newton-Raphson root-finder."
+  SYNC: grmhd_primitives_allbutBi
+} "Apply outflow-only, flat BCs on {P,rho_b,vx,vy,vz}. Outflow only == velocities pointed inward from outer boundary are set to zero"
 
-schedule GRHayLMHD_set_gz_symmetries in GRHayLMHD_PostPostInitial as mhdpostid after compute_b
+#########################################################
+# Stress-energy Tensor
+#########################################################
+
+schedule GRHayLMHD_compute_Tmunu in AddToTmunu
 {
   LANG: C
-  READS:  GRID::coordinates
-  READS:  grmhd_conservatives,
-          grmhd_B_center, grmhd_B_stagger,
-          phitilde, Ax, Ay, Az
-  #Technically only writes B^i, A_i, and phitilde in symmetry gz's
-  WRITES:  grmhd_B_center(everywhere), grmhd_B_stagger(everywhere),
-           phitilde(everywhere), Ax(everywhere), Ay(everywhere), Az(everywhere)
-# TODO: This should NOT be handled by IGM. Any time cycling should be handled by the driver
-  WRITES: grmhd_conservatives_p(everywhere), phitilde_p(everywhere),
-          Ax_p(everywhere), Ay_p(everywhere), Az_p(everywhere),
-          grmhd_conservatives_p_p(everywhere), phitilde_p_p(everywhere),
-          Ax_p_p(everywhere), Ay_p_p(everywhere), Az_p_p(everywhere)
-} "Compute post-initialdata quantities"
+  READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
+  READS:  HydroBase::eps
+  READS:  grmhd_primitives_allbutBi, u0, grmhd_B_center
+  WRITES: TmunuBase::stress_energy_scalar(everywhere),
+          TmunuBase::stress_energy_vector(everywhere),
+          TmunuBase::stress_energy_tensor(everywhere)
+} "Compute stress-energy tensor"
+
+# This preserves original IllinoisGRMHD behavior, but it's bad form.
+# This prevents usfrom making the Tmunu be "add" instead of "set".
+# The ET wants AddToTmunu, not SetTmunu.
+schedule GRHayLMHD_compute_Tmunu at CCTK_POSTPOSTINITIAL after Con2Prim
+{
+  LANG: C
+  READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
+  READS:  HydroBase::eps
+  READS:  grmhd_primitives_allbutBi, u0, grmhd_B_center
+  WRITES: TmunuBase::stress_energy_scalar(everywhere),
+          TmunuBase::stress_energy_vector(everywhere),
+          TmunuBase::stress_energy_tensor(everywhere)
+} "Compute stress-energy tensor"
 
 #########################################################
 # RHS EVALUATION
@@ -242,98 +247,6 @@ schedule GRHayLMHD_evaluate_phitilde_and_A_gauge_rhs in GRHayLMHD_RHS after GRHa
   WRITES: grmhd_primitives_reconstructed_temps, EM_rhs
 } "Evaluate phitilde RHS and gauge contributions to A_i RHS"
 
-
-#########################################################
-# COMPUTE B FROM A & RE-SOLVE FOR PRIMITIVES
-#########################################################
-# After a full timestep, there are two types of boundaries that need filling:
-# (A) Outer boundaries (on coarsest level)
-# (B) AMR grid refinement boundaries
-
-# (A) OUTER BOUNDARY STEPS:
-# ( 0) Synchronize (prolongate/restrict) all evolved variables
-# ( 1) Apply outer boundary conditions (BCs) on A_{\mu}
-# ( 2) Compute B^i from A_i everywhere, synchronize (processor sync) B^i
-# ( 3) Call con2prim to get consistent primitives {P,rho_b,vx,vy,vz} and conservatives at all points (if no restriction, really only need interior)
-# ( 4) Apply outer BCs on {P,rho_b,vx,vy,vz}, recompute conservatives.
-
-# (B) AMR GRID REFINEMENT BOUNDARY STEPS:
-# Same as steps 0,2,3 above. Just need if() statements in steps 1,4 to prevent "outer boundaries" being updated
-# Problem: all the sync's in outer boundary updates might just overwrite prolongated values.
-#########################################################
-
-# we should be able to get rid of this
-schedule GRHayLMHD_InitSymBound in HydroBase_Boundaries as Boundary_SYNCs
-{
-  LANG: C
-  SYNC: grmhd_conservatives, em_Ax, em_Ay, em_Az, em_psi6phi
-} "Schedule symmetries -- Actually just a placeholder function to ensure prolongations / processor syncs are done BEFORE outer boundaries are updated."
-
-schedule GRHayLMHD_outer_boundaries_on_A_mu in HydroBase_Boundaries after Boundary_SYNCs
-{
-  LANG: C
-  READS:  phitilde, Ax, Ay, Az
-  WRITES: phitilde(boundary), Ax(boundary), Ay(boundary), Az(boundary)
-} "Apply linear extrapolation BCs on A_{mu}, so that BCs are flat on B^i."
- 
-schedule GRHayLMHD_convert_ADM_to_BSSN in HydroBase_Boundaries after Boundary_SYNCs
-{
-   LANG: C
-   READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
-   WRITES: ADMBase::metric(everywhere)
-   WRITES: BSSN_quantities(everywhere)
-   #SC: loop is everywhere, so there should be no syncs; either the loop is wrong or there should be no syncs.
-} "Enforce BSSN metric is conformally flat and recompute ADM metric."
-
-# again, everywhere loop + sync
-# Easiest primitives to solve for: B^i.
-# Note however that B^i depends on derivatives of A_{\mu}, so a SYNC is necessary on B^i.
-schedule GRHayLMHD_compute_B_and_Bstagger_from_A in HydroBase_Boundaries after GRHayLMHD_outer_boundaries_on_A_mu after GRHayLMHD_convert_ADM_to_BSSN
-{
-  LANG: C
-  READS:  GRID::coordinates
-  READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
-  READS:  psi_bssn, phitilde, Ax, Ay, Az
-  #Technically only writes Ai and phitilde in symmetry gz's
-  WRITES: phitilde(everywhere), Ax(everywhere), Ay(everywhere), Az(everywhere),
-          grmhd_B_center(everywhere), grmhd_B_stagger(everywhere)
-  # This is strictly a processor sync, as prolongation is disabled for all primitives & B^i's.
-  SYNC: grmhd_B_center, grmhd_B_stagger # FIXME: Are both SYNC's necessary?
-} "Compute B and B_stagger from A,  SYNC: grmhd_primitives_Bi,grmhd_primitives_Bi_stagger"
-
-# Nontrivial primitives solve, for P,rho_b,vx,vy,vz.
-schedule GRHayLMHD_conserv_to_prims in AddToTmunu
-{
-  LANG: C
-  READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
-  READS:  grmhd_conservatives, grmhd_B_center
-  # C2P Shouldn't actually change B^i, but we return the values via the return_primitives() anyways
-  # in the event a new C2P for some reason touches B^i
-  WRITES: grmhd_primitives_allbutBi(everywhere), grmhd_B_center(everywhere),
-          grmhd_conservatives(everywhere), failure_checker(everywhere)
-  WRITES: HydroBase::eps(everywhere)
-  WRITES: TmunuBase::stress_energy_scalar(everywhere),
-          TmunuBase::stress_energy_vector(everywhere),
-          TmunuBase::stress_energy_tensor(everywhere)
-} "Compute primitive variables from conservatives. This is non-trivial, requiring a Newton-Raphson root-finder."
-
-schedule GRHayLMHD_outer_boundaries_on_P_rho_b_vx_vy_vz in AddToTmunu after GRHayLMHD_conserv_to_prims
-{
-  LANG: C
-  READS:  ADMBase::metric, ADMBase::lapse, ADMBase::shift
-  READS:  grmhd_B_center
-  # C2P Shouldn't actually change B^i, but we return the values via the return_primitives() anyways
-  # in the event a new C2P for some reason touches B^i
-  WRITES: grmhd_primitives_allbutBi(everywhere), grmhd_B_center(everywhere),
-          grmhd_conservatives(everywhere), failure_checker(everywhere)
-  WRITES: HydroBase::eps(everywhere)
-  WRITES: TmunuBase::stress_energy_scalar(everywhere),
-          TmunuBase::stress_energy_vector(everywhere),
-          TmunuBase::stress_energy_tensor(everywhere)
-# We must sync {P,rho_b,vx,vy,vz} here.
-  SYNC: grmhd_primitives_allbutBi
-} "Apply outflow-only, flat BCs on {P,rho_b,vx,vy,vz}. Outflow only == velocities pointed inward from outer boundary are set to zero."
-
 #########################################################
 # Conversion from GRHayLMHD variables to Hydrobase
 #########################################################
@@ -347,5 +260,3 @@ SCHEDULE convert_GRHayLMHD_to_HydroBase at CCTK_ANALYSIS before (compute_bi_b2_P
   WRITES: HydroBase::rho(everywhere), HydroBase::press(everywhere),
           HydroBase::vel(everywhere), HydroBase::w_lorentz(everywhere), HydroBase::Bvec(everywhere)
 } "Convert GRHayLMHD-native variables to HydroBase"
-
-#########################################################

--- a/implementations/GRHayLMHD/src/compute_Tmunu.c
+++ b/implementations/GRHayLMHD/src/compute_Tmunu.c
@@ -1,0 +1,49 @@
+#include "GRHayLMHD.h"
+
+void GRHayLMHD_compute_Tmunu(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTS_GRHayLMHD_compute_Tmunu;
+  DECLARE_CCTK_PARAMETERS;
+
+  const double poison = 0.0/0.0;
+
+#pragma omp parallel for
+  for(int k=0; k<cctk_lsh[2]; k++) {
+    for(int j=0; j<cctk_lsh[1]; j++) {
+      for(int i=0; i<cctk_lsh[0]; i++) {
+        const int index = CCTK_GFINDEX3D(cctkGH,i,j,k);
+
+        // Read in ADM metric quantities from gridfunctions and
+        // set auxiliary and ADM metric quantities
+        metric_quantities ADM_metric;
+        ghl_enforce_detgtij_and_initialize_ADM_metric(
+              alp[index],
+              betax[index], betay[index], betaz[index],
+              gxx[index], gxy[index], gxz[index],
+              gyy[index], gyz[index], gzz[index],
+              &ADM_metric);
+
+        ADM_aux_quantities metric_aux;
+        ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+
+        // Read in primitive variables from gridfunctions
+        primitive_quantities prims;
+        ghl_initialize_primitives(
+              rho_b[index], pressure[index], eps[index],
+              vx[index], vy[index], vz[index],
+              Bx_center[index], By_center[index], Bz_center[index],
+              poison, poison, poison, &prims);
+
+        prims.u0 = u0[index];
+
+        stress_energy Tmunu;
+        ghl_compute_TDNmunu(&ADM_metric, &metric_aux, &prims, &Tmunu);
+
+        ghl_return_stress_energy(
+              &Tmunu, &eTtt[index], &eTtx[index],
+              &eTty[index], &eTtz[index], &eTxx[index],
+              &eTxy[index], &eTxz[index], &eTyy[index],
+              &eTyz[index], &eTzz[index]);
+      }
+    }
+  }
+}

--- a/implementations/GRHayLMHD/src/conservs_to_prims.c
+++ b/implementations/GRHayLMHD/src/conservs_to_prims.c
@@ -72,9 +72,9 @@ void GRHayLMHD_conserv_to_prims(CCTK_ARGUMENTS) {
   double dummy1, dummy2, dummy3;
 
 #pragma omp parallel for reduction(+:failures,vel_limited_ptcount,atm_resets,rho_star_fix_applied,pointcount,failures_inhoriz,pointcount_inhoriz,backup0,backup1,backup2,nan_found,error_int_numer,error_int_denom,n_iter) schedule(static)
-  for(int k=0;k<cctk_lsh[2];k++) {
-    for(int j=0;j<cctk_lsh[1];j++) {
-      for(int i=0;i<cctk_lsh[0];i++) {
+  for(int k=0; k<cctk_lsh[2]; k++) {
+    for(int j=0; j<cctk_lsh[1]; j++) {
+      for(int i=0; i<cctk_lsh[0]; i++) {
         const int index = CCTK_GFINDEX3D(cctkGH,i,j,k);
 
         con2prim_diagnostics diagnostics;
@@ -136,8 +136,8 @@ void GRHayLMHD_conserv_to_prims(CCTK_ARGUMENTS) {
 
           /************* Conservative-to-primitive recovery ************/
           int check = ghl_con2prim_multi_method(
-                grhayl_params, grhayl_eos, &ADM_metric,
-                &metric_aux, &cons_undens, &prims, &diagnostics);
+                grhayl_params, grhayl_eos, &ADM_metric, &metric_aux,
+                &cons_undens, &prims, &diagnostics);
 
           if(check==0) {
             //Check for NAN!
@@ -190,12 +190,11 @@ void GRHayLMHD_conserv_to_prims(CCTK_ARGUMENTS) {
         //---------- Primitive recovery succeeded ----------
         //--------------------------------------------------
         // Enforce limits on primitive variables and recompute conservatives.
-        stress_energy Tmunu;
         ghl_enforce_primitive_limits_and_compute_u0(
               grhayl_params, grhayl_eos, &ADM_metric, &metric_aux,
               &prims, &diagnostics.failure_checker);
-        ghl_compute_conservs_and_Tmunu(
-              &ADM_metric, &metric_aux, &prims, &cons, &Tmunu);
+        ghl_compute_conservs(
+              &ADM_metric, &metric_aux, &prims, &cons);
 
         //Now we compute the difference between original & new conservatives, for diagnostic purposes:
         error_int_numer += fabs(cons.tau - cons_orig.tau) + fabs(cons.rho - cons_orig.rho) + fabs(cons.SD[0] - cons_orig.SD[0])
@@ -218,20 +217,13 @@ void GRHayLMHD_conserv_to_prims(CCTK_ARGUMENTS) {
               &vx[index], &vy[index], &vz[index],
               &Bx_center[index], &By_center[index], &Bz_center[index],
               &dummy1, &dummy2, &dummy3);
+        u0[index] = prims.u0;
 
         ghl_return_conservatives(
               &cons,
               &rho_star[index], &tau[index],
               &Stildex[index], &Stildey[index], &Stildez[index],
               &dummy1, &dummy2);
-
-        if(update_Tmunu) {
-          ghl_return_stress_energy(
-                &Tmunu, &eTtt[index], &eTtx[index],
-                &eTty[index], &eTtz[index], &eTxx[index],
-                &eTxy[index], &eTxz[index], &eTyy[index],
-                &eTyz[index], &eTzz[index]);
-        }
 
         pointcount++;
         failures += diagnostics.failures;

--- a/implementations/GRHayLMHD/src/convert_HydroBase_to_GRHayLMHD.c
+++ b/implementations/GRHayLMHD/src/convert_HydroBase_to_GRHayLMHD.c
@@ -268,15 +268,14 @@ void convert_HydroBase_to_GRHayLMHD(CCTK_ARGUMENTS) {
               &prims);
 
         conservative_quantities cons;
-        stress_energy Tmunu;
         int speed_limited = 0;
         //This applies inequality fixes on the conservatives
         ghl_enforce_primitive_limits_and_compute_u0(
               grhayl_params, grhayl_eos, &ADM_metric,
               &metric_aux, &prims, &speed_limited);
         //This computes the conservatives and stress-energy tensor from the new primitives
-        ghl_compute_conservs_and_Tmunu(
-              &ADM_metric, &metric_aux, &prims, &cons, &Tmunu);
+        ghl_compute_conservs(
+              &ADM_metric, &metric_aux, &prims, &cons);
 
         ghl_return_primitives(
               &prims,
@@ -290,14 +289,6 @@ void convert_HydroBase_to_GRHayLMHD(CCTK_ARGUMENTS) {
               &rho_star[index], &tau[index],
               &Stildex[index], &Stildey[index], &Stildez[index],
               &dummy1, &dummy2);
-
-        if(update_Tmunu) {
-          ghl_return_stress_energy(
-                &Tmunu, &eTtt[index], &eTtx[index],
-                &eTty[index], &eTtz[index], &eTxx[index],
-                &eTxy[index], &eTxz[index], &eTyy[index],
-                &eTyz[index], &eTzz[index]);
-        }
       }
     }
   }

--- a/implementations/GRHayLMHD/src/make.code.defn
+++ b/implementations/GRHayLMHD/src/make.code.defn
@@ -4,6 +4,7 @@
 SRCS = A_flux_rhs.c                                \
        calculate_MHD_rhs.c                         \
        compute_B_and_Bstagger_from_A.c             \
+       compute_Tmunu.c                             \
        conservs_to_prims.c                         \
        convert_ADM_to_BSSN.c                       \
        convert_HydroBase_to_GRHayLMHD.c            \

--- a/implementations/GRHayLMHD/src/outer_boundaries.c
+++ b/implementations/GRHayLMHD/src/outer_boundaries.c
@@ -11,7 +11,7 @@
 
 #include "GRHayLMHD.h"
 
-#define IDX(i,j,k) CCTK_GFINDEX3D(cctkGH,(i),(j),(k))
+void GRHayLMHD_enforce_primitive_limits_and_compute_conservs(const cGH* cctkGH, const int index);
 
 /*********************************************
  * Apply outer boundary conditions on A_{\mu}
@@ -39,68 +39,98 @@ void GRHayLMHD_outer_boundaries_on_A_mu(CCTK_ARGUMENTS) {
     if(cctk_bbox[1]) {
       const int imax=cctk_lsh[0]-cctk_nghostzones[0]+which_bdry_pt;
 #pragma omp parallel for
-      for(int k=0; k<cctk_lsh[2]; k++)
+      for(int k=0; k<cctk_lsh[2]; k++) {
         for(int j=0; j<cctk_lsh[1]; j++) {
-          phitilde[IDX(imax,j,k)] = 2.0 * phitilde[IDX(imax-1,j,k)] - phitilde[IDX(imax-2,j,k)];
-          Ax[IDX(imax,j,k)] = 2.0 * Ax[IDX(imax-1,j,k)] - Ax[IDX(imax-2,j,k)];
-          Ay[IDX(imax,j,k)] = 2.0 * Ay[IDX(imax-1,j,k)] - Ay[IDX(imax-2,j,k)];
-          Az[IDX(imax,j,k)] = 2.0 * Az[IDX(imax-1,j,k)] - Az[IDX(imax-2,j,k)];
+          const int indm2 = CCTK_GFINDEX3D(cctkGH,imax-2, j, k);
+          const int indm1 = CCTK_GFINDEX3D(cctkGH,imax-1, j, k);
+          const int index = CCTK_GFINDEX3D(cctkGH,imax, j, k);
+
+          phitilde[index] = 2.0 * phitilde[indm1] - phitilde[indm2];
+          Ax[index] = 2.0 * Ax[indm1] - Ax[indm2];
+          Ay[index] = 2.0 * Ay[indm1] - Ay[indm2];
+          Az[index] = 2.0 * Az[indm1] - Az[indm2];
+        }
       }
     }
     if(cctk_bbox[3]) {
       const int jmax=cctk_lsh[1]-cctk_nghostzones[1]+which_bdry_pt;
 #pragma omp parallel for
-      for(int k=0; k<cctk_lsh[2]; k++)
+      for(int k=0; k<cctk_lsh[2]; k++) {
         for(int i=0; i<cctk_lsh[0]; i++) {
-          phitilde[IDX(i,jmax,k)] = 2.0 * phitilde[IDX(i,jmax-1,k)] - phitilde[IDX(i,jmax-2,k)];
-          Ax[IDX(i,jmax,k)] = 2.0 * Ax[IDX(i,jmax-1,k)] - Ax[IDX(i,jmax-2,k)];
-          Ay[IDX(i,jmax,k)] = 2.0 * Ay[IDX(i,jmax-1,k)] - Ay[IDX(i,jmax-2,k)];
-          Az[IDX(i,jmax,k)] = 2.0 * Az[IDX(i,jmax-1,k)] - Az[IDX(i,jmax-2,k)];
+          const int indm2 = CCTK_GFINDEX3D(cctkGH, i, jmax-2, k);
+          const int indm1 = CCTK_GFINDEX3D(cctkGH, i, jmax-1, k);
+          const int index = CCTK_GFINDEX3D(cctkGH, i, jmax, k);
+
+          phitilde[index] = 2.0 * phitilde[indm1] - phitilde[indm2];
+          Ax[index] = 2.0 * Ax[indm1] - Ax[indm2];
+          Ay[index] = 2.0 * Ay[indm1] - Ay[indm2];
+          Az[index] = 2.0 * Az[indm1] - Az[indm2];
+        }
       }
     }
     if(cctk_bbox[5]) {
       const int kmax=cctk_lsh[2]-cctk_nghostzones[2]+which_bdry_pt;
 #pragma omp parallel for
-      for(int j=0; j<cctk_lsh[1]; j++)
+      for(int j=0; j<cctk_lsh[1]; j++) {
         for(int i=0; i<cctk_lsh[0]; i++) {
-          phitilde[IDX(i,j,kmax)] = 2.0 * phitilde[IDX(i,j,kmax-1)] - phitilde[IDX(i,j,kmax-2)];
-          Ax[IDX(i,j,kmax)] = 2.0 * Ax[IDX(i,j,kmax-1)] - Ax[IDX(i,j,kmax-2)];
-          Ay[IDX(i,j,kmax)] = 2.0 * Ay[IDX(i,j,kmax-1)] - Ay[IDX(i,j,kmax-2)];
-          Az[IDX(i,j,kmax)] = 2.0 * Az[IDX(i,j,kmax-1)] - Az[IDX(i,j,kmax-2)];
+          const int indm2 = CCTK_GFINDEX3D(cctkGH, i, j, kmax-2);
+          const int indm1 = CCTK_GFINDEX3D(cctkGH, i, j, kmax-1);
+          const int index = CCTK_GFINDEX3D(cctkGH, i, j, kmax);
+
+          phitilde[index] = 2.0 * phitilde[indm1] - phitilde[indm2];
+          Ax[index] = 2.0 * Ax[indm1] - Ax[indm2];
+          Ay[index] = 2.0 * Ay[indm1] - Ay[indm2];
+          Az[index] = 2.0 * Az[indm1] - Az[indm2];
+        }
       }
     }
 
     if(cctk_bbox[0]) {
       const int imin=cctk_nghostzones[0]-which_bdry_pt-1;
 #pragma omp parallel for
-      for(int k=0; k<cctk_lsh[2]; k++)
+      for(int k=0; k<cctk_lsh[2]; k++) {
         for(int j=0; j<cctk_lsh[1]; j++) {
-          phitilde[IDX(imin,j,k)] = 2.0 * phitilde[IDX(imin+1,j,k)] - phitilde[IDX(imin+2,j,k)];
-          Ax[IDX(imin,j,k)] = 2.0 * Ax[IDX(imin+1,j,k)] - Ax[IDX(imin+2,j,k)];
-          Ay[IDX(imin,j,k)] = 2.0 * Ay[IDX(imin+1,j,k)] - Ay[IDX(imin+2,j,k)];
-          Az[IDX(imin,j,k)] = 2.0 * Az[IDX(imin+1,j,k)] - Az[IDX(imin+2,j,k)];
+          const int index = CCTK_GFINDEX3D(cctkGH, imin, j, k);
+          const int indp1 = CCTK_GFINDEX3D(cctkGH, imin+1, j, k);
+          const int indp2 = CCTK_GFINDEX3D(cctkGH, imin+2, j, k);
+
+          phitilde[index] = 2.0 * phitilde[indp1] - phitilde[indp2];
+          Ax[index] = 2.0 * Ax[indp1] - Ax[indp2];
+          Ay[index] = 2.0 * Ay[indp1] - Ay[indp2];
+          Az[index] = 2.0 * Az[indp1] - Az[indp2];
+        }
       }
     }
     if(cctk_bbox[2]) {
       const int jmin=cctk_nghostzones[1]-which_bdry_pt-1;
 #pragma omp parallel for
-      for(int k=0; k<cctk_lsh[2]; k++)
+      for(int k=0; k<cctk_lsh[2]; k++) {
         for(int i=0; i<cctk_lsh[0]; i++) {
-          phitilde[IDX(i,jmin,k)] = 2.0 * phitilde[IDX(i,jmin+1,k)] - phitilde[IDX(i,jmin+2,k)];
-          Ax[IDX(i,jmin,k)] = 2.0 * Ax[IDX(i,jmin+1,k)] - Ax[IDX(i,jmin+2,k)];
-          Ay[IDX(i,jmin,k)] = 2.0 * Ay[IDX(i,jmin+1,k)] - Ay[IDX(i,jmin+2,k)];
-          Az[IDX(i,jmin,k)] = 2.0 * Az[IDX(i,jmin+1,k)] - Az[IDX(i,jmin+2,k)];
+          const int index = CCTK_GFINDEX3D(cctkGH, i, jmin, k);
+          const int indp1 = CCTK_GFINDEX3D(cctkGH, i, jmin+1, k);
+          const int indp2 = CCTK_GFINDEX3D(cctkGH, i, jmin+2, k);
+
+          phitilde[index] = 2.0 * phitilde[indp1] - phitilde[indp2];
+          Ax[index] = 2.0 * Ax[indp1] - Ax[indp2];
+          Ay[index] = 2.0 * Ay[indp1] - Ay[indp2];
+          Az[index] = 2.0 * Az[indp1] - Az[indp2];
+        }
       }
     }
     if((cctk_bbox[4]) && Symmetry_none) {
       const int kmin=cctk_nghostzones[2]-which_bdry_pt-1;
 #pragma omp parallel for
-      for(int j=0; j<cctk_lsh[1]; j++)
+      for(int j=0; j<cctk_lsh[1]; j++) {
         for(int i=0; i<cctk_lsh[0]; i++) {
-          phitilde[IDX(i,j,kmin)] = 2.0 * phitilde[IDX(i,j,kmin+1)] - phitilde[IDX(i,j,kmin+2)];
-          Ax[IDX(i,j,kmin)] = 2.0 * Ax[IDX(i,j,kmin+1)] - Ax[IDX(i,j,kmin+2)];
-          Ay[IDX(i,j,kmin)] = 2.0 * Ay[IDX(i,j,kmin+1)] - Ay[IDX(i,j,kmin+2)];
-          Az[IDX(i,j,kmin)] = 2.0 * Az[IDX(i,j,kmin+1)] - Az[IDX(i,j,kmin+2)];
+          const int index = CCTK_GFINDEX3D(cctkGH, i, j, kmin);
+          const int indp1 = CCTK_GFINDEX3D(cctkGH, i, j, kmin+1);
+          const int indp2 = CCTK_GFINDEX3D(cctkGH, i, j, kmin+2);
+
+          phitilde[index] = 2.0 * phitilde[indp1] - phitilde[indp2];
+          Ax[index] = 2.0 * Ax[indp1] - Ax[indp2];
+          Ay[index] = 2.0 * Ay[indp1] - Ay[indp2];
+          Az[index] = 2.0 * Az[indp1] - Az[indp2];
+        }
       }
     }
   }
@@ -137,12 +167,16 @@ void GRHayLMHD_outer_boundaries_on_P_rho_b_vx_vy_vz(CCTK_ARGUMENTS) {
 #pragma omp parallel for
       for(int k=0; k<cctk_lsh[2]; k++) {
         for(int j=0; j<cctk_lsh[1]; j++) {
-          pressure[IDX(imax,j,k)] = pressure[IDX(imax-1,j,k)];
-          rho_b[IDX(imax,j,k)]   = rho_b[IDX(imax-1,j,k)];
-          vx[IDX(imax,j,k)]    = vx[IDX(imax-1,j,k)];
-          vy[IDX(imax,j,k)]    = vy[IDX(imax-1,j,k)];
-          vz[IDX(imax,j,k)]    = vz[IDX(imax-1,j,k)]; 
-          if(vx[IDX(imax,j,k)]<0.) vx[IDX(imax,j,k)] = 0.0;
+          const int indm1 = CCTK_GFINDEX3D(cctkGH,imax-1, j, k);
+          const int index = CCTK_GFINDEX3D(cctkGH,imax, j, k);
+
+          pressure[index] = pressure[indm1];
+          rho_b[index]    = rho_b[indm1];
+          vx[index]       = vx[indm1];
+          vy[index]       = vy[indm1];
+          vz[index]       = vz[indm1]; 
+          if(vx[index]<0.) vx[index] = 0.0;
+          GRHayLMHD_enforce_primitive_limits_and_compute_conservs(cctkGH, index);
         }
       }
     }
@@ -152,12 +186,16 @@ void GRHayLMHD_outer_boundaries_on_P_rho_b_vx_vy_vz(CCTK_ARGUMENTS) {
 #pragma omp parallel for
       for(int k=0; k<cctk_lsh[2]; k++) {
         for(int j=0; j<cctk_lsh[1]; j++) {
-          pressure[IDX(imin,j,k)] = pressure[IDX(imin+1,j,k)];
-          rho_b[IDX(imin,j,k)]   = rho_b[IDX(imin+1,j,k)];
-          vx[IDX(imin,j,k)]    = vx[IDX(imin+1,j,k)];
-          vy[IDX(imin,j,k)]    = vy[IDX(imin+1,j,k)];
-          vz[IDX(imin,j,k)]    = vz[IDX(imin+1,j,k)]; 
-          if(vx[IDX(imin,j,k)]>0.) vx[IDX(imin,j,k)] = 0.0;
+          const int index = CCTK_GFINDEX3D(cctkGH, imin, j, k);
+          const int indp1 = CCTK_GFINDEX3D(cctkGH, imin+1, j, k);
+
+          pressure[index] = pressure[indp1];
+          rho_b[index]    = rho_b[indp1];
+          vx[index]       = vx[indp1];
+          vy[index]       = vy[indp1];
+          vz[index]       = vz[indp1]; 
+          if(vx[index]>0.) vx[index] = 0.0;
+          GRHayLMHD_enforce_primitive_limits_and_compute_conservs(cctkGH, index);
         }
       }
     }
@@ -169,12 +207,16 @@ void GRHayLMHD_outer_boundaries_on_P_rho_b_vx_vy_vz(CCTK_ARGUMENTS) {
 #pragma omp parallel for
       for(int k=0; k<cctk_lsh[2]; k++) {
         for(int i=0; i<cctk_lsh[0]; i++) {
-          pressure[IDX(i,jmax,k)] = pressure[IDX(i,jmax-1,k)];
-          rho_b[IDX(i,jmax,k)]   = rho_b[IDX(i,jmax-1,k)];
-          vx[IDX(i,jmax,k)]    = vx[IDX(i,jmax-1,k)];
-          vy[IDX(i,jmax,k)]    = vy[IDX(i,jmax-1,k)];
-          vz[IDX(i,jmax,k)]    = vz[IDX(i,jmax-1,k)]; 
-          if(vx[IDX(i,jmax,k)]<0.) vx[IDX(i,jmax,k)] = 0.0;
+          const int indm1 = CCTK_GFINDEX3D(cctkGH, i, jmax-1, k);
+          const int index = CCTK_GFINDEX3D(cctkGH, i, jmax, k);
+
+          pressure[index] = pressure[indm1];
+          rho_b[index]    = rho_b[indm1];
+          vx[index]       = vx[indm1];
+          vy[index]       = vy[indm1];
+          vz[index]       = vz[indm1]; 
+          if(vx[index]<0.) vx[index] = 0.0;
+          GRHayLMHD_enforce_primitive_limits_and_compute_conservs(cctkGH, index);
         }
       }
     }
@@ -184,12 +226,16 @@ void GRHayLMHD_outer_boundaries_on_P_rho_b_vx_vy_vz(CCTK_ARGUMENTS) {
 #pragma omp parallel for
       for(int k=0; k<cctk_lsh[2]; k++) {
         for(int i=0; i<cctk_lsh[0]; i++) {
-          pressure[IDX(i,jmin,k)] = pressure[IDX(i,jmin+1,k)];
-          rho_b[IDX(i,jmin,k)]   = rho_b[IDX(i,jmin+1,k)];
-          vx[IDX(i,jmin,k)]    = vx[IDX(i,jmin+1,k)];
-          vy[IDX(i,jmin,k)]    = vy[IDX(i,jmin+1,k)];
-          vz[IDX(i,jmin,k)]    = vz[IDX(i,jmin+1,k)]; 
-          if(vx[IDX(i,jmin,k)]>0.) vx[IDX(i,jmin,k)] = 0.0;
+          const int index = CCTK_GFINDEX3D(cctkGH, i, jmin, k);
+          const int indp1 = CCTK_GFINDEX3D(cctkGH, i, jmin+1, k);
+
+          pressure[index] = pressure[indp1];
+          rho_b[index]    = rho_b[indp1];
+          vx[index]       = vx[indp1];
+          vy[index]       = vy[indp1];
+          vz[index]       = vz[indp1]; 
+          if(vx[index]>0.) vx[index] = 0.0;
+          GRHayLMHD_enforce_primitive_limits_and_compute_conservs(cctkGH, index);
         }
       }
     }
@@ -201,12 +247,16 @@ void GRHayLMHD_outer_boundaries_on_P_rho_b_vx_vy_vz(CCTK_ARGUMENTS) {
 #pragma omp parallel for
       for(int j=0; j<cctk_lsh[1]; j++) {
         for(int i=0; i<cctk_lsh[0]; i++) {
-          pressure[IDX(i,j,kmax)] = pressure[IDX(i,j,kmax-1)];
-          rho_b[IDX(i,j,kmax)]   = rho_b[IDX(i,j,kmax-1)];
-          vx[IDX(i,j,kmax)]    = vx[IDX(i,j,kmax-1)];
-          vy[IDX(i,j,kmax)]    = vy[IDX(i,j,kmax-1)];
-          vz[IDX(i,j,kmax)]    = vz[IDX(i,j,kmax-1)]; 
-          if(vx[IDX(i,j,kmax)]<0.) vx[IDX(i,j,kmax)] = 0.0;
+          const int indm1 = CCTK_GFINDEX3D(cctkGH, i, j, kmax-1);
+          const int index = CCTK_GFINDEX3D(cctkGH, i, j, kmax);
+
+          pressure[index] = pressure[indm1];
+          rho_b[index]    = rho_b[indm1];
+          vx[index]       = vx[indm1];
+          vy[index]       = vy[indm1];
+          vz[index]       = vz[indm1]; 
+          if(vx[index]<0.) vx[index] = 0.0;
+          GRHayLMHD_enforce_primitive_limits_and_compute_conservs(cctkGH, index);
         }
       }
     }
@@ -216,84 +266,67 @@ void GRHayLMHD_outer_boundaries_on_P_rho_b_vx_vy_vz(CCTK_ARGUMENTS) {
 #pragma omp parallel for
       for(int j=0; j<cctk_lsh[1]; j++) {
         for(int i=0; i<cctk_lsh[0]; i++) {
-          pressure[IDX(i,j,kmin)] = pressure[IDX(i,j,kmin+1)];
-          rho_b[IDX(i,j,kmin)]   = rho_b[IDX(i,j,kmin+1)];
-          vx[IDX(i,j,kmin)]    = vx[IDX(i,j,kmin+1)];
-          vy[IDX(i,j,kmin)]    = vy[IDX(i,j,kmin+1)];
-          vz[IDX(i,j,kmin)]    = vz[IDX(i,j,kmin+1)]; 
-          if(vx[IDX(i,j,kmin)]>0.) vx[IDX(i,j,kmin)] = 0.0;
+          const int index = CCTK_GFINDEX3D(cctkGH, i, j, kmin);
+          const int indp1 = CCTK_GFINDEX3D(cctkGH, i, j, kmin+1);
+
+          pressure[index] = pressure[indp1];
+          rho_b[index]    = rho_b[indp1];
+          vx[index]       = vx[indp1];
+          vy[index]       = vy[indp1];
+          vz[index]       = vz[indp1]; 
+          if(vx[index]>0.) vx[index] = 0.0;
+          GRHayLMHD_enforce_primitive_limits_and_compute_conservs(cctkGH, index);
         }
       }
     }
   }
+}
+
+void GRHayLMHD_enforce_primitive_limits_and_compute_conservs(const cGH* cctkGH, const int index) {
+  // We cheat here by using the argument list of the scheduled function
+  // instead of explicitly passing all these variables.
+  DECLARE_CCTK_ARGUMENTS_GRHayLMHD_outer_boundaries_on_P_rho_b_vx_vy_vz;
 
   const double poison = 0.0/0.0;
   double dummy1, dummy2, dummy3;
+  int speed_limited = 0;
 
-#pragma omp parallel for
-  for(int k=0; k<cctk_lsh[2]; k++) {
-    for(int j=0; j<cctk_lsh[1]; j++) {
-      for(int i=0; i<cctk_lsh[0]; i++) {
-        if(((cctk_bbox[0]) && i<cctk_nghostzones[0]) ||
-           ((cctk_bbox[1]) && i>=cctk_lsh[0]-cctk_nghostzones[0]) ||
-           ((cctk_bbox[2]) && j<cctk_nghostzones[1]) ||
-           ((cctk_bbox[3]) && j>=cctk_lsh[1]-cctk_nghostzones[1]) ||
-           ((cctk_bbox[4]) && k<cctk_nghostzones[2] && CCTK_EQUALS(Symmetry,"none")) ||
-           ((cctk_bbox[5]) && k>=cctk_lsh[2]-cctk_nghostzones[2])) {
-          const int index = CCTK_GFINDEX3D(cctkGH,i,j,k);
+  metric_quantities ADM_metric;
+  ghl_enforce_detgtij_and_initialize_ADM_metric(
+        alp[index],
+        betax[index], betay[index], betaz[index],
+        gxx[index], gxy[index], gxz[index],
+        gyy[index], gyz[index], gzz[index],
+        &ADM_metric);
 
-          metric_quantities ADM_metric;
-          ghl_enforce_detgtij_and_initialize_ADM_metric(
-                alp[index],
-                betax[index], betay[index], betaz[index],
-                gxx[index], gxy[index], gxz[index],
-                gyy[index], gyz[index], gzz[index],
-                &ADM_metric);
-      
-        ADM_aux_quantities metric_aux;
-        ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+  ADM_aux_quantities metric_aux;
+  ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-          primitive_quantities prims;
-          ghl_initialize_primitives(
-                rho_b[index], pressure[index], eps[index],
-                vx[index], vy[index], vz[index],
-                Bx_center[index], By_center[index], Bz_center[index],
-                poison, poison, poison, &prims);
-                //wont have storage for these vars for hybrid
-                //entropy[index], Y_e[index], temperature[index], &prims);
+  primitive_quantities prims;
+  ghl_initialize_primitives(
+        rho_b[index], pressure[index], eps[index],
+        vx[index], vy[index], vz[index],
+        Bx_center[index], By_center[index], Bz_center[index],
+        poison, poison, poison, &prims);
 
-          conservative_quantities cons;
-          stress_energy Tmunu;
-          int speed_limited = 0;
-          ghl_enforce_primitive_limits_and_compute_u0(
-                grhayl_params, grhayl_eos, &ADM_metric,
-                &metric_aux, &prims, &speed_limited);
-          ghl_compute_conservs_and_Tmunu(
-                &ADM_metric, &metric_aux, &prims, &cons, &Tmunu);
+  conservative_quantities cons;
+  ghl_enforce_primitive_limits_and_compute_u0(
+        grhayl_params, grhayl_eos, &ADM_metric,
+        &metric_aux, &prims, &speed_limited);
 
-          ghl_return_primitives(
-                &prims,
-                &rho_b[index], &pressure[index], &eps[index],
-                &vx[index], &vy[index], &vz[index],
-                &Bx_center[index], &By_center[index], &Bz_center[index],
-                &dummy1, &dummy2, &dummy3);
+  ghl_compute_conservs(
+        &ADM_metric, &metric_aux, &prims, &cons);
 
-          ghl_return_conservatives(
-                &cons,
-                &rho_star[index], &tau[index],
-                &Stildex[index], &Stildey[index], &Stildez[index],
-                &dummy1, &dummy2);
-                //&Y_e[index], &entropy[index]);
+  ghl_return_primitives(
+        &prims,
+        &rho_b[index], &pressure[index], &eps[index],
+        &vx[index], &vy[index], &vz[index],
+        &Bx_center[index], &By_center[index], &Bz_center[index],
+        &dummy1, &dummy2, &dummy3);
 
-          if(update_Tmunu) {
-            ghl_return_stress_energy(
-                  &Tmunu, &eTtt[index], &eTtx[index],
-                  &eTty[index], &eTtz[index], &eTxx[index],
-                  &eTxy[index], &eTxz[index], &eTyy[index],
-                  &eTyz[index], &eTzz[index]);
-          }
-        }
-      }
-    }
-  }
+  ghl_return_conservatives(
+        &cons,
+        &rho_star[index], &tau[index],
+        &Stildex[index], &Stildey[index], &Stildez[index],
+        &dummy1, &dummy2);
 }

--- a/implementations/TestDataID/src/1D_tests_hydro_data.c
+++ b/implementations/TestDataID/src/1D_tests_hydro_data.c
@@ -81,9 +81,9 @@ void TestDataID_1D_tests_hydro_data(CCTK_ARGUMENTS) {
   }
 
 #pragma omp parallel for
-  for(int k=0;k<cctk_lsh[2];k++) {
-    for(int j=0;j<cctk_lsh[1];j++) {
-      for(int i=0;i<cctk_lsh[0];i++) {
+  for(int k=0; k<cctk_lsh[2]; k++) {
+    for(int j=0; j<cctk_lsh[1]; j++) {
+      for(int i=0; i<cctk_lsh[0]; i++) {
         int index = CCTK_GFINDEX3D(cctkGH,i,j,k);
         int ind4x = CCTK_GFINDEX4D(cctkGH,i,j,k,0);
         int ind4y = CCTK_GFINDEX4D(cctkGH,i,j,k,1);


### PR DESCRIPTION
This PR affects GRHayLHD and GRHayLMHD. It splits the computation of primitives and conservatives in the con2prim from the computation of Tmunu. It also removes the use of con2prim routines in some other functions which run directly before the actual con2prim scheduled function. Finally, it cleans up the scheduling.